### PR TITLE
App folder starts with an uppercase

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "digitalnature/php-ref": "dev-master"
   },
   "autoload": {
-    "psr-4": {"App\\": "app/"}
+    "psr-4": {"App\\": "App/"}
   },
   "minimum-stability" : "dev"
 }


### PR DESCRIPTION
You'll encounter an issue if you're on a case-sentitive OS (like me, on Ubuntu)
