### PR TITLE
Fixed download after major changes at laracasts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,7 @@
 EMAIL=test.com
 PASSWORD=password
+ALGOLIA_APP_ID=
+ALGOLIA_API_KEY=
 LOCAL_PATH=Downloads
 LESSONS_FOLDER=lessons
 SERIES_FOLDER=series

--- a/App/Algolia/Controller.php
+++ b/App/Algolia/Controller.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * Algolia Controller
+ */
+namespace App\Algolia;
+
+use AlgoliaSearch\Client;
+use App\Downloader;
+use App\Exceptions\AlgoliaException;
+
+/**
+ * Class Controller
+ * @package App\Algolia
+ */
+class Controller
+{
+    /**
+     * Client lib
+     * @var Client
+     */
+    private $client;
+
+    /**
+     * Receives dependencies
+     *
+     * @param Client $client
+     */
+    public function __construct(Client $client)
+    {
+        $this->client = $client;
+    }
+
+    /**
+     * Grabs all lessons & series from the algolia api.
+     *
+     * @return array
+     * @throws \AlgoliaSearch\AlgoliaException
+     */
+    public function getAllLessons()
+    {
+        $index = $this->client->initIndex(ALGOLIA_INDEX_NAME);
+
+        $page = 0;
+        $params = [
+            'facetFilters' => [
+                [
+                    'type:lesson',
+                    'type:series',
+                ],
+            ],
+            'attributesToRetrieve' =>  [
+                'path',
+                'type',
+                'slug',
+                'episode_count',
+            ],
+            'page' => $page,
+        ];
+
+        $array = [
+            'lessons' => [],
+            'series' => [],
+        ];
+
+        do {
+            try {
+                $res = $index->search('', $params);
+            } catch (\Exception $e) {
+                throw new AlgoliaException($e->getMessage(), $e->getCode(), $e);
+            }
+            $params['page'] = $res['page'] + 1;
+
+            foreach ($res['hits'] as $lessonInfo) {
+                switch ($lessonInfo['type']) {
+                    case 'lesson':
+                        $path = $lessonInfo['path'];
+                        if (preg_match('/'.LARACASTS_LESSONS_PATH.'\/(.+)/', $path, $matches)) { // lesson
+                            $array['lessons'][] = $matches[1];
+                        }
+                        break;
+                    case 'series':
+                        $serieSlug = $lessonInfo['slug'];
+                        foreach (range(1, $lessonInfo['episode_count']) as $episode) {
+                            $array['series'][$serieSlug][] = $episode;
+                        }
+                        break;
+                    default:
+                        break;
+                }
+            }
+
+        } while ($res['page'] <= $res['nbPages']);
+
+        Downloader::$currentLessonNumber = count($array['lessons']);
+
+        return $array;
+    }
+
+}

--- a/App/Exceptions/AlgoliaException.php
+++ b/App/Exceptions/AlgoliaException.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Algolia Exception
+ */
+namespace App\Exceptions;
+
+use Exception;
+use Throwable;
+
+/**
+ * Class AlgoliaException
+ * @package App\Exceptions
+ */
+class AlgoliaException extends Exception
+{
+    /**
+     * AlgoliaException constructor.
+     *
+     * @param string $message
+     * @param int $code
+     * @param Throwable|null $previous
+     */
+    public function __construct(string $message = "", int $code = 0, Throwable $previous = null)
+    {
+        parent::__construct('Algolia error: ' . $message, $code, $previous);
+    }
+}

--- a/App/Html/Parser.php
+++ b/App/Html/Parser.php
@@ -14,49 +14,6 @@ use Symfony\Component\DomCrawler\Crawler;
 class Parser
 {
     /**
-     * Parses the html and adds the lessons the the array.
-     *
-     * @param $html
-     * @param $array
-     */
-    public static function getAllLessons($html, &$array)
-    {
-        $parser = new Crawler($html);
-
-        $parser->filter('h5.lesson-list-title')->each(function (Crawler $node) use (&$array) {
-            $link = $node->children()->attr('href');
-            if (preg_match('/'.LARACASTS_LESSONS_PATH.'\/(.+)/', $link, $matches)) { // lesson
-                $array['lessons'][] = $matches[1];
-            } else if ($node->children()->count() > 0) {
-                $link = $node->children()->eq(0)->attr('href');
-
-                if (preg_match('/'.LARACASTS_SERIES_PATH.'\/(.+)\/episodes\/(\d+)/', $link, $matches)) { // serie lesson
-                    $array['series'][$matches[1]][] = (int) $matches[2];
-                }
-            }
-        });
-    }
-
-    /**
-     * Determines if there is next page, false if not or the link.
-     *
-     * @param $html
-     *
-     * @return bool|string
-     */
-    public static function hasNextPage($html)
-    {
-        $parser = new Crawler($html);
-
-        $node = $parser->filter('[rel=next]');
-        if ($node->count() > 0) {
-            return $node->attr('href');
-        }
-
-        return false;
-    }
-
-    /**
      * Gets the token input.
      *
      * @param $html
@@ -99,7 +56,7 @@ class Parser
     public static function getNameOfEpisode($html, $path)
     {
         $parser = new Crawler($html);
-        $t = $parser->filter("a[href='/".$path."']")->text();
+        $t = $parser->filter("a[href='/".$path."'] h6")->text();
 
         return trim($t);
     }

--- a/App/Http/Resolver.php
+++ b/App/Http/Resolver.php
@@ -61,56 +61,6 @@ class Resolver
     }
 
     /**
-     * Grabs all lessons & series from the website.
-     */
-    public function getAllLessons()
-    {
-        $array = [];
-        $html = $this->getAllPage();
-        Parser::getAllLessons($html, $array);
-
-        while ($nextPage = Parser::hasNextPage($html)) {
-            $html = $this->client->get($nextPage, ['verify' => false])->getBody()->getContents();
-            Parser::getAllLessons($html, $array);
-        }
-
-        Downloader::$currentLessonNumber = count($array['lessons']);
-
-        return $array;
-    }
-
-    /**
-     * Gets the latest lessons only.
-     *
-     * @return array
-     *
-     * @throws \Exception
-     */
-    public function getLatestLessons()
-    {
-        $array = [];
-
-        $html = $this->getAllPage();
-        Parser::getAllLessons($html, $array);
-
-        return $array;
-    }
-
-    /**
-     * Gets the html from the all page.
-     *
-     * @return string
-     *
-     * @throws \Exception
-     */
-    private function getAllPage()
-    {
-        $response = $this->client->get(LARACASTS_ALL_PATH, ['verify' => false]);
-
-        return $response->getBody()->getContents();
-    }
-
-    /**
      * Tries to auth.
      *
      * @param $email

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Downloads new lessons and series from laracasts if there are updates. Or the whole catalogue.
 
-**Working good at 14/09/2018**
+**Working good at 10/11/2018**
 
 ## Description
 Syncs your local folder with the laracasts website, when there are new lessons the app download it for you.
@@ -23,11 +23,15 @@ Even to download free lessons or series. The download option is only allowed to 
 - PHP >= 5.4
 - php-cURL
 - php-xml
+- php-json
 - Composer
 
 ## Installation
 - Clone this repo to a folder in your machine
 - Change your info in .env.example and rename it to .env
+  - Go to [laracasts.com --> Browse](https://laracasts.com/search), open Dev Tools --> Network,
+   find a request to algolia.net and save `x-algolia-api-key` and `x-algolia-application-id`
+   values to your .env
 - `composer install`
 - `php start.php` and you are done!
 

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -27,15 +27,20 @@ $options['lessons_folder'] = getenv('LESSONS_FOLDER');
 $options['series_folder'] = getenv('SERIES_FOLDER');
 //Flags
 $options['retry_download'] = boolval(getenv('RETRY_DOWNLOAD'));
+//Algolia
+$options['algolia_app_id'] = getenv('ALGOLIA_APP_ID');
+$options['algolia_api_key'] = getenv('ALGOLIA_API_KEY');
 
 define('BASE_FOLDER', $options['local_path']);
 define('LESSONS_FOLDER', $options['lessons_folder']);
 define('SERIES_FOLDER', $options['series_folder']);
 define('RETRY_DOWNLOAD', $options['retry_download']);
+define('ALGOLIA_APP_ID', $options['algolia_app_id']);
+define('ALGOLIA_API_KEY', $options['algolia_api_key']);
+define('ALGOLIA_INDEX_NAME', 'lessons');
 
 //laracasts
 define('LARACASTS_BASE_URL', 'https://laracasts.com');
-define('LARACASTS_ALL_PATH', 'lessons');
 define('LARACASTS_LOGIN_PATH', 'login');
 define('LARACASTS_POST_LOGIN_PATH', 'sessions');
 define('LARACASTS_LESSONS_PATH', 'lessons');

--- a/composer.json
+++ b/composer.json
@@ -9,9 +9,11 @@
     "symfony/css-selector": "~3.0@dev",
     "devster/ubench": "~1.1@dev",
     "ext-curl": "*",
+    "ext-json": "*",
     "ext-xml": "*",
     "vlucas/phpdotenv": "^2.3",
-    "cocur/slugify": "^2.3"
+    "cocur/slugify": "^2.3",
+    "algolia/algoliasearch-client-php": "~1.28"
   },
   "require-dev": {
     "digitalnature/php-ref": "dev-master"

--- a/composer.lock
+++ b/composer.lock
@@ -1,12 +1,67 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "hash": "7d35941fd36d149186fe2317daa8a0a1",
-    "content-hash": "966a425f454333d7022081f1765b077a",
+    "content-hash": "1b4cb21e9376b88347e97733b7ef7f0b",
     "packages": [
+        {
+            "name": "algolia/algoliasearch-client-php",
+            "version": "1.28.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/algolia/algoliasearch-client-php.git",
+                "reference": "c167ba3247b38b028fc05b1c58e8b5fb5e08d114"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/algolia/algoliasearch-client-php/zipball/c167ba3247b38b028fc05b1c58e8b5fb5e08d114",
+                "reference": "c167ba3247b38b028fc05b1c58e8b5fb5e08d114",
+                "shasum": ""
+            },
+            "require": {
+                "ext-curl": "*",
+                "ext-mbstring": "*",
+                "php": "^5.3 || ^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.4 || ^7.0",
+                "satooshi/php-coveralls": "^1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-2.0": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "AlgoliaSearch": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Algolia Team",
+                    "email": "contact@algolia.com"
+                },
+                {
+                    "name": "Ryan T. Catlin",
+                    "email": "ryan.catlin@gmail.com"
+                },
+                {
+                    "name": "Jonathan H. Wage",
+                    "email": "jonwage@gmail.com"
+                }
+            ],
+            "description": "Algolia Search API Client for PHP",
+            "homepage": "https://github.com/algolia/algoliasearch-client-php",
+            "time": "2018-11-06T10:48:00+00:00"
+        },
         {
             "name": "cocur/slugify",
             "version": "2.3.x-dev",
@@ -69,7 +124,7 @@
                 "slug",
                 "slugify"
             ],
-            "time": "2016-08-09 20:10:17"
+            "time": "2016-08-09T20:10:17+00:00"
         },
         {
             "name": "devster/ubench",
@@ -114,7 +169,7 @@
                 "library",
                 "micro"
             ],
-            "time": "2015-06-02 08:26:32"
+            "time": "2015-06-02T08:26:32+00:00"
         },
         {
             "name": "guzzlehttp/guzzle",
@@ -167,7 +222,7 @@
                 "rest",
                 "web service"
             ],
-            "time": "2017-01-05 06:25:03"
+            "time": "2017-01-05T06:25:03+00:00"
         },
         {
             "name": "guzzlehttp/ringphp",
@@ -218,7 +273,7 @@
                 }
             ],
             "description": "Provides a simple API and specification that abstracts away the details of HTTP into a single PHP function.",
-            "time": "2017-01-13 20:44:38"
+            "time": "2017-01-13T20:44:38+00:00"
         },
         {
             "name": "guzzlehttp/streams",
@@ -268,7 +323,7 @@
                 "Guzzle",
                 "stream"
             ],
-            "time": "2016-04-13 16:32:01"
+            "time": "2016-04-13T16:32:01+00:00"
         },
         {
             "name": "league/flysystem",
@@ -351,7 +406,7 @@
                 "sftp",
                 "storage"
             ],
-            "time": "2017-01-29 13:44:21"
+            "time": "2017-01-29T13:44:21+00:00"
         },
         {
             "name": "react/promise",
@@ -394,7 +449,7 @@
                 "promise",
                 "promises"
             ],
-            "time": "2016-12-22 14:09:01"
+            "time": "2016-12-22T14:09:01+00:00"
         },
         {
             "name": "symfony/css-selector",
@@ -447,7 +502,7 @@
             ],
             "description": "Symfony CssSelector Component",
             "homepage": "https://symfony.com",
-            "time": "2017-01-02 20:33:09"
+            "time": "2017-01-02T20:33:09+00:00"
         },
         {
             "name": "symfony/dom-crawler",
@@ -503,7 +558,7 @@
             ],
             "description": "Symfony DomCrawler Component",
             "homepage": "https://symfony.com",
-            "time": "2017-01-21 16:40:50"
+            "time": "2017-01-21T16:40:50+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
@@ -562,7 +617,7 @@
                 "portable",
                 "shim"
             ],
-            "time": "2016-11-14 01:06:16"
+            "time": "2016-11-14T01:06:16+00:00"
         },
         {
             "name": "vlucas/phpdotenv",
@@ -612,7 +667,7 @@
                 "env",
                 "environment"
             ],
-            "time": "2016-12-14 21:01:27"
+            "time": "2016-12-14T21:01:27+00:00"
         }
     ],
     "packages-dev": [
@@ -649,7 +704,7 @@
                 "debug",
                 "var_dump"
             ],
-            "time": "2016-12-21 18:21:24"
+            "time": "2016-12-21T18:21:24+00:00"
         }
     ],
     "aliases": [],
@@ -663,6 +718,7 @@
     "prefer-lowest": false,
     "platform": {
         "ext-curl": "*",
+        "ext-json": "*",
         "ext-xml": "*"
     },
     "platform-dev": []

--- a/start.php
+++ b/start.php
@@ -13,11 +13,12 @@ require_once 'bootstrap.php';
 $client = new GuzzleHttp\Client(['base_url' => LARACASTS_BASE_URL]);
 $filesystem = new Filesystem(new Adapter(BASE_FOLDER));
 $bench = new Ubench();
+$algolia = new AlgoliaSearch\Client(ALGOLIA_APP_ID, ALGOLIA_API_KEY);
 
 /*
  * App
  */
-$app = new App\Downloader($client, $filesystem, $bench, RETRY_DOWNLOAD);
+$app = new App\Downloader($client, $filesystem, $bench, $algolia, RETRY_DOWNLOAD);
 
 try {
     $app->start($options);


### PR DESCRIPTION
Fixes #74 

After laracasts recent changes, lessons and series cannot be crawled anymore because now that info is loaded via xhr requests through Algolia API. I switched the crawler with an Angolia client and updated README with new intructions.

**The ALGOLIA_APP_ID and ALGOLIA_API_KEY env variables must be filled manually.**

It would be nice if someone does another pr crawling them from the js files