### PR TITLE
Scraping /series/ to get all new series and episode counts at once.

### DIFF
--- a/App/Algolia/Controller.php
+++ b/App/Algolia/Controller.php
@@ -7,7 +7,6 @@ namespace App\Algolia;
 use AlgoliaSearch\Client;
 use App\Downloader;
 use App\Exceptions\AlgoliaException;
-use App\Http\Resolver;
 
 /**
  * Class Controller
@@ -81,8 +80,7 @@ class Controller
                         break;
                     case 'series':
                         $serieSlug = $lessonInfo['slug'];
-                        $episode_count = $this->getRealEpisodeCount($lessonInfo['path']);
-                        foreach (range(1, $episode_count) as $episode) {
+                        foreach (range(1, $lessonInfo['episode_count']) as $episode) {
                             $array['series'][$serieSlug][] = $episode;
                         }
                         break;
@@ -96,16 +94,6 @@ class Controller
         Downloader::$currentLessonNumber = count($array['lessons']);
 
         return $array;
-    }
-
-    private function getRealEpisodeCount($path)
-    {
-        global $client, $bench;
-        $retryDownload = false;
-
-        $resolver = new Resolver($client, $bench, $retryDownload);
-
-        return $resolver->getRealEpisodeCount($path);
     }
 
 }

--- a/App/Html/Parser.php
+++ b/App/Html/Parser.php
@@ -61,11 +61,22 @@ class Parser
         return trim($t);
     }
 
-    public static function getRealEpisodeCount($html)
+    public static function getSeriesArray($html)
     {
-        preg_match('/(\d+) episodes/', $html, $results);
-        $episode_count = intval($results[1]);
+        $parser = new Crawler($html);
 
-        return $episode_count;
+        $seriesNodes = $parser->filter(".series-card");
+
+        $series = $seriesNodes->each(function(Crawler $crawler) {
+            $slug = str_replace('/series/', '', $crawler->filter('a.tw-block')->attr('href'));
+            $episode_count = (int) $crawler->filter('.card-bottom .card-stats div div.tw-text-xs.tw-font-semibold')->text();
+
+            return [
+                'slug' => $slug,
+                'episode_count' => $episode_count,
+            ];
+        });
+
+        return $series;
     }
 }

--- a/App/Http/Resolver.php
+++ b/App/Http/Resolver.php
@@ -148,13 +148,6 @@ class Resolver
         return $this->downloadLessonFromPath($html, $saveTo);
     }
 
-    public function getRealEpisodeCount($path)
-    {
-        $episodePage = $this->getPage($path);
-
-        return Parser::getRealEpisodeCount($episodePage);
-    }
-
     /**
      * Helper function to get html of a page
      * @param $path

--- a/App/Laracasts/Controller.php
+++ b/App/Laracasts/Controller.php
@@ -1,0 +1,80 @@
+<?php
+
+
+namespace App\Laracasts;
+
+
+use App\Html\Parser;
+use GuzzleHttp\Client;
+use GuzzleHttp\Cookie\CookieJar;
+
+class Controller
+{
+    /**
+     * @var \GuzzleHttp\Client
+     */
+    private $client;
+    /**
+     * @var array
+     */
+    private $algoliaResults;
+
+    /**
+     * Controller constructor.
+     * @param Client $client
+     */
+    public function __construct(Client $client)
+    {
+        $this->client = $client;
+        $this->cookie = new CookieJar();
+    }
+
+    /**
+     * Adds algolia results for use while merging
+     *
+     * @param array $algoliaLessons
+     */
+    public function addAlgoliaResults(array $algoliaLessons)
+    {
+        $this->algoliaResults = $algoliaLessons;
+    }
+
+    /**
+     *  Gets all series with scraping and merges with algolia result
+     *
+     * @return array
+     * @throws \Exception
+     */
+    public function getAllSeries()
+    {
+        if (empty($this->algoliaResults)) throw new \Exception('algoliaResults is empty, use addAlgoliaResults() to add a result');
+
+        $seriesHtml = $this->getSeriesHtml();
+
+        $mergedResult = $this->algoliaResults;
+
+        $series = Parser::getSeriesArray($seriesHtml);
+
+        foreach ($series as $serie) {
+            foreach (range(1, $serie['episode_count']) as $episode) {
+                $key = $episode - 1; // Since we override we can't just append to the array
+                $mergedResult['series'][$serie['slug']][$key] = $episode;
+            }
+        }
+
+        return $mergedResult;
+    }
+
+    /**
+     * Returns series page html
+     *
+     * @return string
+     */
+    private function getSeriesHtml()
+    {
+        return $this->client
+            ->get(LARACASTS_BASE_URL . '/' . LARACASTS_SERIES_PATH, ['cookies' => $this->cookie, 'verify' => false])
+            ->getBody()
+            ->getContents();
+    }
+}


### PR DESCRIPTION
I've reverted the algolia controller and created a new class laracasts which scrapes /series.
This single page contains all current series as well as their correct episode count.

The new code merges the algolia result with the scraping to get a combined list of series to download.

I can't see any flaws in it and am running it now to test. The data structure is correct and I haven't really touched the part of the code which does the actual downloading.

I'll comment tomorrow with the results of the test run.