### PR TITLE
Fix parsing for the new design

### DIFF
--- a/App/Html/Parser.php
+++ b/App/Html/Parser.php
@@ -36,7 +36,7 @@ class Parser
      */
     public static function getDownloadLink($html)
     {
-        preg_match("('\/downloads\/.*?')", $html, $matches);
+        preg_match("(\"\/downloads\/.*?\")", $html, $matches);
 
         if(isset($matches[0]) === false) {
             throw new NoDownloadLinkException();
@@ -56,7 +56,7 @@ class Parser
     public static function getNameOfEpisode($html, $path)
     {
         $parser = new Crawler($html);
-        $t = $parser->filter("a[href='/".$path."'] h6")->text();
+        $t = $parser->filter("h4 a[href='/".$path."']")->text();
 
         return trim($t);
     }


### PR DESCRIPTION
The design of the Laracasts website was changed today and downloading stopped working for me. It turned out to be because of parsing. 
I fixed the parsing for episode names and download links, and now it's working again. 
Please check if the changes are valid.