### PR TITLE
Gracefully handle future-scheduled lessons.

### DIFF
--- a/App/Html/Parser.php
+++ b/App/Html/Parser.php
@@ -46,6 +46,23 @@ class Parser
     }
 
     /**
+     * Determine if this episode is scheduled for the future.
+     *
+     * @param $html
+     * @return boolean
+     */
+    public static function scheduledEpisode($html)
+    {
+        preg_match("(return to watch it (.*)\.)", $html, $matches);
+
+        if (isset($matches[1])) {
+            return strip_tags($matches[1]);
+        }
+
+        return false;
+    }
+
+    /**
      * Extracts the name of the episode.
      *
      * @param $html

--- a/App/Http/Resolver.php
+++ b/App/Http/Resolver.php
@@ -202,6 +202,12 @@ class Resolver
      */
     private function downloadLessonFromPath($html, $saveTo)
     {
+        $scheduled = Parser::scheduledEpisode($html);
+        if ($scheduled !== false) {
+            Utils::write(sprintf("This lesson is not available yet. Retry later: %s", $scheduled));
+            return false;
+        }
+
         try {
             $downloadUrl = Parser::getDownloadLink($html);
             $viemoUrl = $this->getRedirectUrl($downloadUrl);


### PR DESCRIPTION
Previously when a video was scheduled to be published, it wasn't displayed. Laracasts now displays these future-scheduled lessons, however.. this change handles that gracefully, with output like the following:

```
> Download started: 03 - The Laravel Installer . . . . Saving on series/laravel-6-from-scratch folder.
> This lesson is not available yet. Retry later: 12 hours from now
> Current: 1 of 2 total. Left: 1

> Download started: 04 - Laravel Valet Setup . . . . Saving on series/laravel-6-from-scratch folder.
> This lesson is not available yet. Retry later: 1 day from now
> Current: 2 of 2 total. Left: 0

> Finished! Downloaded 0 new lessons and 0 new episodes. Failed: 2
```