### PR TITLE
Handle redirect when series episode page not found

### DIFF
--- a/App/Exceptions/EpisodePageNotFoundException.php
+++ b/App/Exceptions/EpisodePageNotFoundException.php
@@ -1,0 +1,11 @@
+<?php
+/**
+ * The episode page was not found
+ */
+namespace App\Exceptions;
+
+use Exception;
+
+class EpisodePageNotFoundException extends Exception
+{
+}


### PR DESCRIPTION
Fixes #94 

I noticed the episode count shown on the series cards on /series page is different than the actual episode count. 

Here it says 29 episodes
![image](https://user-images.githubusercontent.com/9071956/66645270-a6ae1780-ec40-11e9-9b09-8db694087cf0.png)

But there are only 28 episodes:
![image](https://user-images.githubusercontent.com/9071956/66645358-dd842d80-ec40-11e9-8fb0-d9d41df354cb.png)

So when crawler tries to fetch /series/laravel-6-from-scratch/episodes/29 page it is redirected to /series/laravel-6-from-scratch

This caused the error: **The current node list is empty**.

I have disallowed the redirect on this specific request and added an exception to log it. 

Kindly suggest if there's a better approach to solve this issue. 