### PR TITLE
Update crawler html selector for series page

### DIFF
--- a/App/Html/Parser.php
+++ b/App/Html/Parser.php
@@ -82,11 +82,11 @@ class Parser
     {
         $parser = new Crawler($html);
 
-        $seriesNodes = $parser->filter(".series-card");
+        $seriesNodes = $parser->filter(".card");
 
         $series = $seriesNodes->each(function(Crawler $crawler) {
-            $slug = str_replace('/series/', '', $crawler->filter('a.tw-block')->attr('href'));
-            $episode_count = (int) $crawler->filter('.card-bottom .card-stats div div.tw-text-xs.tw-font-semibold')->text();
+            $slug = str_replace('/series/', '', $crawler->filter('.expanded-card-heading a')->attr('href'));
+            $episode_count = (int) $crawler->filter('.expanded-card-meta-lessons a')->text();
 
             return [
                 'slug' => $slug,


### PR DESCRIPTION
This PR fixes #100 .
Algolia result is not up to date; even in main website ([laracasts](https://laracasts.com/search)) you can't get any result for "code katas in phpunit" or newer course like "javascript-techniques-for-server-side-developers".
And @carlosflorencio knews about that and he was scrapping series page and merging them with algolia result in ``App/Laracasts/Controller.php``.
But query selector is out dated. I just update crawler filtering and it works fine. 