### PR TITLE
Changes to series page markup/classes

### DIFF
--- a/App/Html/Parser.php
+++ b/App/Html/Parser.php
@@ -82,11 +82,11 @@ class Parser
     {
         $parser = new Crawler($html);
 
-        $seriesNodes = $parser->filter(".card");
+        $seriesNodes = $parser->filter(".expanded-card-meta-lessons a");
 
         $series = $seriesNodes->each(function(Crawler $crawler) {
-            $slug = str_replace('/series/', '', $crawler->filter('.expanded-card-heading a')->attr('href'));
-            $episode_count = (int) $crawler->filter('.expanded-card-meta-lessons a')->text();
+            $slug = str_replace('/series/', '', $crawler->attr('href'));
+            $episode_count = (int) $crawler->text();
 
             return [
                 'slug' => $slug,

--- a/App/System/Controller.php
+++ b/App/System/Controller.php
@@ -62,6 +62,9 @@ class Controller
             if ($entry['type'] != 'file') {
                 continue;
             } //skip folder, we only want the files
+            if (substr($entry['filename'], 0, 2) == '._') {
+                continue;
+            }
 
             $serie   = substr($entry['dirname'], strlen(SERIES_FOLDER) + 1);
             $episode = (int)substr($entry['filename'], 0, strpos($entry['filename'], '-'));

--- a/README.md
+++ b/README.md
@@ -6,7 +6,10 @@
 
 Downloads new lessons and series from laracasts if there are updates. Or the whole catalogue.
 
-**This is working as of `2020-02-09`, although you are rate limited to 30 downloads every 24 hours.**
+### LIMITED FUNCTIONALITY NOTE:
+Due to recent changes in the structure of the series page, it is no longer possible to fetch the full catalog
+of lessons and series. Between a lengthy (unknown) delay on algolia indexing, and incomplete list of content
+on the series page, ability to download is severely hindered.
 
 ## Description
 Syncs your local folder with the laracasts website, when there are new lessons the app download it for you.


### PR DESCRIPTION
Fixes #112 ... see it for more detail.

This will get newly added items that appear on the page as "recently updated" to work, but older items that no longer appear on the page won't.

So, maybe not for everyone.