### PR TITLE
Scrap individual series page to get exact number of episodes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ App/.DS_Store
 .DS_Store
 
 .phpintel/
+Downloads/cache.php

--- a/App/Downloader.php
+++ b/App/Downloader.php
@@ -111,7 +111,8 @@ class Downloader
             $localLessons = $this->system->getAllLessons();
             $algoliaLessons = $this->algolia->getAllLessons();
             $this->laracasts->addAlgoliaResults($algoliaLessons);
-            $allLessonsOnline = $this->laracasts->getAllSeries();
+            $allLessonsOnline = $this->laracasts->getAllSeries($this->system->getCacheData());
+            $this->system->cacheSeriesData($allLessonsOnline);
 
             $this->bench->end();
 

--- a/App/Html/Parser.php
+++ b/App/Html/Parser.php
@@ -96,4 +96,12 @@ class Parser
 
         return $series;
     }
+
+
+    public static function getEpisodesCount($html)
+    {
+        $parser = new Crawler($html);
+
+        return $parser->filter("ol li.episode-list-item")->count();
+    }
 }

--- a/App/Html/Parser.php
+++ b/App/Html/Parser.php
@@ -104,4 +104,10 @@ class Parser
 
         return $parser->filter("ol li.episode-list-item")->count();
     }
+
+
+    public static function isCourseComplete($html)
+    {
+        return strpos($html, 'Series still in development. Check back often for updates') === false;
+    }
 }

--- a/App/Http/Resolver.php
+++ b/App/Http/Resolver.php
@@ -132,6 +132,9 @@ class Resolver
         } catch (EpisodePageNotFoundException $e) {
             Utils::write(sprintf($e->getMessage()));
             return false;
+        } catch (\Exception $e) {
+            Utils::write(sprintf($e->getMessage()));
+            return false;
         }
     }
 

--- a/App/Laracasts/Controller.php
+++ b/App/Laracasts/Controller.php
@@ -49,16 +49,14 @@ class Controller
     {
         if (empty($this->algoliaResults)) throw new \Exception('algoliaResults is empty, use addAlgoliaResults() to add a result');
 
-        $seriesHtml = $this->getSeriesHtml();
-
         $mergedResult = $this->algoliaResults;
 
-        $series = Parser::getSeriesArray($seriesHtml);
+        foreach($this->algoliaResults['series'] as $slug => $algoliaCourse) {
+            $episodesCount = Parser::getEpisodesCount($this->getCourseHTML($slug));
 
-        foreach ($series as $serie) {
-            foreach (range(1, $serie['episode_count']) as $episode) {
+            foreach (range(1, $episodesCount) as $episode) {
                 $key = $episode - 1; // Since we override we can't just append to the array
-                $mergedResult['series'][$serie['slug']][$key] = $episode;
+                $mergedResult['series'][$slug][$key] = $episode;
             }
         }
 
@@ -74,6 +72,20 @@ class Controller
     {
         return $this->client
             ->get(LARACASTS_BASE_URL . '/' . LARACASTS_SERIES_PATH, ['cookies' => $this->cookie, 'verify' => false])
+            ->getBody()
+            ->getContents();
+    }
+
+    /**
+     * Returns specific course page html
+     *
+     * @param string $slug
+     * @return string
+     */
+    private function getCourseHTML($slug)
+    {
+        return $this->client
+            ->get(LARACASTS_BASE_URL . '/' . LARACASTS_SERIES_PATH . '/' . $slug, ['cookies' => $this->cookie, 'verify' => false])
             ->getBody()
             ->getContents();
     }

--- a/App/System/Controller.php
+++ b/App/System/Controller.php
@@ -245,4 +245,27 @@ class Controller
             $this->system->createDir($folder);
         }
     }
+
+    /**
+     * Create cache file
+     */
+    public function cacheSeriesData($data)
+    {
+        $file = 'cache.php';
+
+        if ($this->system->has($file)) {
+            $this->system->delete($file);
+        }
+
+        $this->system->write($file, '<?php return ' . var_export($data, true) . ';' . PHP_EOL);
+    }
+
+    public function getCacheData()
+    {
+        $file = 'cache.php';
+
+        return $this->system->has($file)
+            ? require $this->system->getAdapter()->getPathPrefix() . 'cache.php'
+            : null;
+    }
 }


### PR DESCRIPTION
Hey @carlosflorencio 
I did following stuff on my local in order to download all episodes. It works fine so I decided to send a pull request; maybe be usefull for someone-else.
1) First of all we are getting series' slug from Algolia (like before). duo to incorrect 'episode_count' value on Algolia's result; I decided to scrap each of series page to get episode's count.
2) Because it's gonna take a long time to parse every single series page, I'm caching the result on ``cache.php`` in order to refer to this file later on.

I know it has expensive time execution (about 1 and half minute on first try) and not ready for merging with master branch, but it was the only way I found to download all of episodes so far (except " What I Learned About Cypress on Day 2").