### PR TITLE
Fix parsing after Laracasts switched to Inertia SSR (data-page in <script> tag)

### DIFF
--- a/App/Html/Parser.php
+++ b/App/Html/Parser.php
@@ -94,7 +94,12 @@ class Parser
     {
         $parser = new Crawler($html);
 
-        $data = $parser->filter('#app')->attr('data-page');
+        // Laracasts (Inertia SSR) now stores the page payload in a
+        // <script data-page> tag; older markup used the #app attribute.
+        $script = $parser->filter('script[data-page]');
+        $data = $script->count()
+            ? $script->text()
+            : $parser->filter('#app')->attr('data-page');
 
         return json_decode((string) $data, true);
     }


### PR DESCRIPTION
## Problem

The downloader currently fails for everyone. After authenticating it errors out during data collection:

```
Warning: Trying to access array offset on null in App/Html/Parser.php on line 79
...
ERROR: unexpected response structure for series.
```

## Root cause

Laracasts moved its frontend to **Inertia SSR**. The page payload (the JSON that everything is parsed from) used to live as an attribute on the app div:

```html
<div id="app" data-page="{...json...}">
```

It now lives in a **separate script tag**, and `#app` is just a server-rendered placeholder:

```html
<div id="app" data-server-rendered>...</div>
<script type="application/json" data-page>{...json...}</script>
```

`Parser::getData()` still read `#app`'s `data-page` attribute, so it returned `null`. That `null` propagated into `getUserData()` (the array-offset warnings) and `getSeries()` (the "unexpected response structure" exception).

The JSON **structure** inside is unchanged (`props.auth.user`, `props.series.data`, `props.series.meta.last_page`, etc.), so only the extraction point needed fixing.

## Fix

Read `data-page` from the `<script data-page>` tag when present, falling back to the legacy `#app[data-page]` attribute for backwards compatibility:

```php
$script = $parser->filter('script[data-page]');
$data = $script->count()
    ? $script->text()
    : $parser->filter('#app')->attr('data-page');
```

## Testing

Ran `php start.php` against a live account end-to-end:
- Before: crashed with the error above.
- After: `> Logged in as ...`, then series are collected and downloads proceed normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)